### PR TITLE
Add SSL port with self-signed certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM nginx:alpine3.20-slim
 
 # for htpasswd command
 RUN apk add --no-cache --update \
-      apache2-utils
+      apache2-utils \
+      openssl
 RUN rm -f /etc/nginx/conf.d/*
 
 ENV SERVER_NAME example.com
@@ -15,6 +16,13 @@ COPY files/run.sh /
 COPY files/nginx.conf.tmpl /
 
 RUN chmod +x /run.sh
+
+# Generate self-signed certificate
+RUN mkdir -p /etc/nginx/ssl && \
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/nginx/ssl/nginx.key \
+    -out /etc/nginx/ssl/nginx.crt \
+    -subj "/CN=localhost"
 
 # use SIGQUIT for graceful shutdown
 # c.f. http://nginx.org/en/docs/control.html

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ $ docker run \
     --name nginx-basic-auth-proxy \
     -p 8080:80 \
     -p 8090:8090 \
+    -p 8443:443 \
     -e BASIC_AUTH_USERNAME=username \
     -e BASIC_AUTH_PASSWORD=password \
     -e PROXY_PASS=https://www.google.com \
     -e SERVER_NAME=proxy.dtan4.net \
     -e PORT=80 \
+    -e SSL_CERT=/etc/nginx/ssl/nginx.crt \
+    -e SSL_KEY=/etc/nginx/ssl/nginx.key \
     ipepe/nginx-basic-auth
 ```
 
@@ -69,6 +72,14 @@ Reading: 0 Writing: 1 Waiting: 0
 |`CLIENT_MAX_BODY_SIZE`|Value for `client_max_body_size` directive|`1m`|
 |`PROXY_READ_TIMEOUT`|Value for `proxy_read_timeout` directive|`60s`|
 |`WORKER_PROCESSES`|Value for `worker_processes` directive|`auto`|
+|`SSL_CERT`|Path to the SSL certificate|`/etc/nginx/ssl/nginx.crt`|
+|`SSL_KEY`|Path to the SSL certificate key|`/etc/nginx/ssl/nginx.key`|
+
+## Self-Signed Certificate
+
+This Docker image generates a self-signed certificate during the build process. The certificate and key are stored in `/etc/nginx/ssl/nginx.crt` and `/etc/nginx/ssl/nginx.key` respectively.
+
+To use the self-signed certificate, you can access the proxy via `https://localhost:8443`. Note that your browser will likely show a warning because the certificate is self-signed.
 
 ## Author
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
     ports:
       - 8080:80
       - 8090:8090
+      - 8443:443
     environment:
       - BASIC_AUTH_USERNAME=username
       - BASIC_AUTH_PASSWORD=password
       - PROXY_PASS=http://web/
+      - SSL_CERT=/etc/nginx/ssl/nginx.crt
+      - SSL_KEY=/etc/nginx/ssl/nginx.key

--- a/files/nginx.conf.tmpl
+++ b/files/nginx.conf.tmpl
@@ -36,4 +36,33 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # Forwarded for header
     }
   }
+
+  server {
+    listen 443 ssl;
+    server_name ##SERVER_NAME##;
+
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+    client_max_body_size ##CLIENT_MAX_BODY_SIZE##;
+    proxy_read_timeout ##PROXY_READ_TIMEOUT##;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    location / {
+      proxy_pass ##PROXY_PASS##;
+      auth_basic "Restricted";
+      auth_basic_user_file /etc/nginx/.htpasswd;
+
+      proxy_set_header X-Forwarded-Host $host;
+      # Do not pass Authorization header to destination
+      proxy_set_header Authorization "";
+      proxy_http_version 1.1;  # Use HTTP/1.1 for WebSocket support
+      proxy_set_header Upgrade $http_upgrade;  # Handle the Upgrade header
+      proxy_set_header Connection "Upgrade";    # Maintain the connection upgrade
+      proxy_set_header Host $host;               # Preserve the original Host header
+      proxy_set_header X-Real-IP $remote_addr;  # Pass the client's IP address
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # Forwarded for header
+    }
+  }
 }

--- a/files/run.sh
+++ b/files/run.sh
@@ -17,6 +17,16 @@ if [ -z $PROXY_PASS ]; then
   exit 1
 fi
 
+if [ -z $SSL_CERT ]; then
+  echo >&2 "SSL_CERT must be set"
+  exit 1
+fi
+
+if [ -z $SSL_KEY ]; then
+  echo >&2 "SSL_KEY must be set"
+  exit 1
+fi
+
 htpasswd -bBc /etc/nginx/.htpasswd $BASIC_AUTH_USERNAME $BASIC_AUTH_PASSWORD
 sed \
   -e "s/##CLIENT_MAX_BODY_SIZE##/$CLIENT_MAX_BODY_SIZE/g" \


### PR DESCRIPTION
Add a second port to nginx configuration with a self-signed localhost certificate generated in the Dockerfile during build.

* **docker-compose.yml**
  - Update port mapping to include 8443:443 for the self-signed certificate.
  - Add environment variables for SSL_CERT and SSL_KEY.

* **Dockerfile**
  - Generate a self-signed localhost certificate during the build process.
  - Copy the generated certificate and key to the appropriate location.

* **files/nginx.conf.tmpl**
  - Add a second server block listening on port 443 with SSL enabled.
  - Configure the server block to use the self-signed certificate and key.

* **files/run.sh**
  - Add checks for SSL_CERT and SSL_KEY environment variables.
  - Update the script to handle the generation and configuration of the self-signed certificate.

* **README.md**
  - Update the run command example to include the new port and environment variables.
  - Add a section explaining the self-signed certificate and how to use it.

